### PR TITLE
Make createJob/run backwards compatible

### DIFF
--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -84,11 +84,11 @@ class QueuedTasksTable extends Table
      * Adds a new job to the queue.
      *
      * @param string $taskName Task name
-     * @param array|null $data Array of data
+     * @param mixed $data Any data
      * @param string|null $notBefore A datetime which indicates when the job may be executed
      * @return \Queue\Model\Entity\QueuedTask Saved job entity
      */
-    public function createJob($taskName, array $data = null, string $notBefore = null): QueuedTask
+    public function createJob($taskName, $data = null, string $notBefore = null): QueuedTask
     {
         $task = [
             'task' => $taskName,

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -240,7 +240,7 @@ TEXT;
             }
 
             /* @phan-suppress-next-line PhanTypeVoidAssignment */
-            $return = $task->run((array)$data, $queuedTask->id);
+            $return = $task->run($data, $queuedTask->id);
             if ($return !== null) {
                 trigger_error('run() should be void and throw exception in error case now.', E_USER_DEPRECATED);
             }

--- a/src/Shell/Task/QueueExampleTask.php
+++ b/src/Shell/Task/QueueExampleTask.php
@@ -75,11 +75,11 @@ class QueueExampleTask extends QueueTask implements AddInterface
      * This function is executed, when a worker is executing a task.
      * The return parameter will determine, if the task will be marked completed, or be requeued.
      *
-     * @param array $data The array passed to QueuedTasksTable::createJob()
+     * @param mixed $data The data passed to QueuedTasksTable::createJob()
      * @param int $taskId The id of the QueuedTask entity
      * @return void
      */
-    public function run(array $data, $taskId): void
+    public function run($data, $taskId): void
     {
         $this->hr();
         $this->out(__d('queue', 'CakePHP Queue Example task.'));

--- a/src/Shell/Task/QueueTaskInterface.php
+++ b/src/Shell/Task/QueueTaskInterface.php
@@ -16,9 +16,9 @@ interface QueueTaskInterface
     /**
      * Main execution of the task.
      *
-     * @param array $data The array passed to QueuedTasksTable::createJob()
+     * @param mixed $data The data passed to QueuedTasksTable::createJob()
      * @param int $taskId The id of the QueuedTask entity
      * @return void
      */
-    public function run(array $data, $taskId): void;
+    public function run($data, $taskId): void;
 }


### PR DESCRIPTION
Noticed some of our jobs can have a single integer as data. Since we're not migrating those and need to run 2.x and 3.x side by side, we'll need to support that type of data.